### PR TITLE
Remove exit() and move redirect logic to the controller.

### DIFF
--- a/Controller/Result/Index.php
+++ b/Controller/Result/Index.php
@@ -100,6 +100,12 @@ class Index extends CatalogSearchResultIndex
             $this->_view->getLayout()->unsetElement('page.main.title');
         } elseif (!$this->proxyHelper->getResultData()->getResponseData()->getResults()->getItems()) {
             $this->_view->loadLayout(static::DEFAULT_NO_RESULT_HANDLE);
+        }
+        elseif ($this->proxyHelper->getResultData()->getLocation()) {
+            // Redirect if there is one in the result.
+            $redirect = $this->resultRedirectFactory->create();
+            $redirect->setUrl($this->proxyHelper->getResultData()->getLocation());
+            return $redirect;
         } elseif ($this->proxyHelper->productsOnly()) {
             $this->_view->loadLayout();
         } else {

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -333,13 +333,6 @@ class Data extends AbstractHelper
 
         }
 
-        // setup redirect if it is in the result
-        if ($this->hawkData->getLocation()) {
-            $this->response->setRedirect($this->hawkData->getLocation())->sendResponse();
-            // phpcs:ignore Magento2.Security.LanguageConstruct.ExitUsage
-            exit(0);
-        }
-
         return $this->hawkData;
     }
 


### PR DESCRIPTION
This removes the use of an exit() and moves the redirect logic to the controller to avoid using an exit() to control the flow of Magento.